### PR TITLE
Feature/allow exploding legacy markers in advanced mode

### DIFF
--- a/Classes/Persistence/MarkerReducerAdvanced.php
+++ b/Classes/Persistence/MarkerReducerAdvanced.php
@@ -243,6 +243,11 @@ final class MarkerReducerAdvanced implements MarkerReducerInterface
         $rebuiltObjects = [];
 
         foreach ($marker as $key => $reducedValue) {
+
+            if (self::isLegacyValue($reducedValue)) {
+                return MarkerReducerLegacy::explode($marker);
+            }
+
             if ($reducedValue instanceof ReducedObject) {
                 $rebuiltObjects[$key] = self::rebuildObjectFromProperties($reducedValue);
             } elseif ($reducedValue instanceof ReducedCollection) {
@@ -401,5 +406,20 @@ final class MarkerReducerAdvanced implements MarkerReducerInterface
     protected static function getLogger(): Logger
     {
         return GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
+    }
+
+    /**
+     * @param $value
+     * @return bool
+     */
+    protected static function isLegacyValue($value): bool
+    {
+        return (is_string($value))
+            && (
+                (strpos(trim($value), MarkerReducerLegacy::NAMESPACE_KEYWORD) === 0)
+                || (strpos(trim($value), MarkerReducerLegacy::NAMESPACE_ARRAY_KEYWORD) === 0)
+                || (strpos(trim($value), MarkerReducerLegacy::NAMESPACE_KEYWORD_OLD) === 0)
+                || (strpos(trim($value), MarkerReducerLegacy::NAMESPACE_ARRAY_KEYWORD_OLD) === 0)
+            );
     }
 }

--- a/Tests/Integration/Persistence/MarkerReducerTest.php
+++ b/Tests/Integration/Persistence/MarkerReducerTest.php
@@ -863,6 +863,37 @@ class MarkerReducerTest extends FunctionalTestCase
     }
 
 
+    /**
+     * @test
+     * @throws \Exception
+     */
+    public function legacyMarkersCanStillBeExplodedInAdvancedMode(): void
+    {
+        //  get a value imploded by legacy
+        //  read it
+        //  convert it with Legecy
+        //  go on
+
+        $this->importCSVDataSet(self::FIXTURE_PATH . '/Database/Check10.csv');
+
+        /** @var \TYPO3\CMS\Extbase\Domain\Model\FrontendUser $entityOne */
+        $entityOne = $this->frontendUserRepository->findByIdentifier(1);
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['accelerator']['markerReducerVersion'] = 'legacy';
+
+        $entityOneLegacy = MarkerReducer::implode(['key' => $entityOne]);
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['accelerator']['markerReducerVersion'] = 'advanced';
+
+        $explodedEntityOne = MarkerReducer::explode($entityOneLegacy);
+
+        self::assertSame($entityOne, $explodedEntityOne['key']);
+
+
+
+    }
+
+
     //=============================================
 
 

--- a/Tests/Integration/Persistence/MarkerReducerTest.php
+++ b/Tests/Integration/Persistence/MarkerReducerTest.php
@@ -869,10 +869,15 @@ class MarkerReducerTest extends FunctionalTestCase
      */
     public function legacyMarkersCanStillBeExplodedInAdvancedMode(): void
     {
-        //  get a value imploded by legacy
-        //  read it
-        //  convert it with Legecy
-        //  go on
+        /**
+         * Scenario:
+         *
+         * Given a marker
+         * Given the marker has been imploded in legacy mode
+         * Given the current mode is changed to advanced
+         * When the method is called
+         * Then the marker is nevertheless exploded to the complete oridinal object
+         */
 
         $this->importCSVDataSet(self::FIXTURE_PATH . '/Database/Check10.csv');
 
@@ -888,8 +893,6 @@ class MarkerReducerTest extends FunctionalTestCase
         $explodedEntityOne = MarkerReducer::explode($entityOneLegacy);
 
         self::assertSame($entityOne, $explodedEntityOne['key']);
-
-
 
     }
 


### PR DESCRIPTION
It may occur that there are stil database entries, which have been imploded in legacy mode, while in the meantime the configuration may have changed to use the advanced mode. In order to explode this already existing items, a detection method has been added to identify legacy mode items. 

In the case, there is a legacy items, a fallback to MarkerReducerLegacy::explode() is implemented to avoid returning null as the MarkerReducerAdvanced would have failed.

As a result a fully exploded marker is returned to work with.